### PR TITLE
Add AGENTS.md and Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Project overview
+
+ThreadOps is a Slack-to-GitHub automation service written in Go.
+
+## Repository layout
+
+```
+go.work                      ← workspace file (local dev only)
+internal/                    ← shared library module
+services/
+  webhook/                   ← webhook service module
+  processor/                 ← processor service module
+e2e/                         ← e2e test module (requires Docker)
+docs/
+  app_spec.txt               ← XML spec; source of truth for architecture
+```
+
+## Validation
+
+### Unit tests
+
+```sh
+make test
+```
+
+### E2E tests
+
+```sh
+make test-e2e
+```
+
+### Build check
+
+```sh
+make build
+```
+
+### Formatting and vet
+
+```sh
+make fmt
+make vet
+```
+
+### Module tidiness
+
+```sh
+make tidy
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: test test-e2e build fmt vet tidy
+
+test:
+	go test ./internal/... ./services/webhook/... ./services/processor/...
+
+test-e2e:
+	docker compose -f e2e/docker-compose.yml up -d
+	go test ./e2e/... ; docker compose -f e2e/docker-compose.yml down -v
+
+build:
+	go build ./services/processor ./services/webhook
+
+fmt:
+	@unformatted=$$(git ls-files '*.go' | xargs gofmt -l); \
+	if [ -n "$$unformatted" ]; then echo "Unformatted files:\n$$unformatted"; exit 1; fi
+
+vet:
+	go vet ./internal/... ./services/webhook/... ./services/processor/... ./e2e/...
+
+tidy:
+	go work sync && for dir in internal services/webhook services/processor e2e; do (cd "$$dir" && go mod tidy); done


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with project context, repository layout, and validation commands for coding agents
- Adds `Makefile` with targets for `test`, `test-e2e`, `build`, `fmt`, `vet`, and `tidy`

Closes #7